### PR TITLE
Fix inverted clamp in default random weight functions (#58)

### DIFF
--- a/src/saga/schedulers/data/random.py
+++ b/src/saga/schedulers/data/random.py
@@ -15,7 +15,7 @@ def _default_task_weight(task: Hashable) -> float:
     Returns:
         float: The task weight.
     """
-    return max(min(1e-9, random.gauss(1, 1 / 3)), 2)
+    return min(max(random.gauss(1, 1 / 3), 1e-9), 2)
 
 
 def _default_dependency_weight(src: Hashable, dst: Hashable) -> float:
@@ -28,7 +28,7 @@ def _default_dependency_weight(src: Hashable, dst: Hashable) -> float:
     Returns:
         float: The dependency weight.
     """
-    return max(min(1e-9, random.gauss(1, 1 / 3)), 2)
+    return min(max(random.gauss(1, 1 / 3), 1e-9), 2)
 
 
 def gen_out_trees(

--- a/tests/test_data_generators.py
+++ b/tests/test_data_generators.py
@@ -1,0 +1,62 @@
+"""Regression tests for the random task-graph/network generators.
+
+These guard against a clamp bug in the default weight functions where an
+inverted ``min``/``max`` made every generated weight collapse to ``2.0``,
+producing fully degenerate (tie-everywhere) instances. See issue #58.
+"""
+
+import random
+
+import pytest
+
+from saga.schedulers.data.random import (
+    _default_dependency_weight,
+    _default_task_weight,
+    gen_in_trees,
+    gen_out_trees,
+    gen_parallel_chains,
+    gen_random_networks,
+)
+
+EPS = 1e-9
+
+
+@pytest.mark.parametrize(
+    "weight_fn",
+    [
+        lambda: _default_task_weight("T0"),
+        lambda: _default_dependency_weight("T0", "T1"),
+    ],
+    ids=["task_weight", "dependency_weight"],
+)
+def test_default_weight_is_clamped_and_not_constant(weight_fn):
+    """Default weights stay within [EPS, 2] and vary across draws."""
+    random.seed(0)
+    samples = [weight_fn() for _ in range(1000)]
+
+    assert all(EPS <= w <= 2 for w in samples), "weights escaped the [EPS, 2] clamp"
+    # The bug pinned every draw to exactly 2.0; a healthy generator spreads out.
+    assert len(set(samples)) > 1, "weights are constant (degenerate instance)"
+    assert any(abs(w - 2.0) > EPS for w in samples), "every weight collapsed to 2.0"
+
+
+def test_generated_task_graphs_are_not_degenerate():
+    """In/out trees and parallel chains have varied, non-degenerate costs."""
+    random.seed(0)
+    graphs = (
+        gen_out_trees(1, num_levels=3, branching_factor=2)
+        + gen_in_trees(1, num_levels=3, branching_factor=2)
+        + gen_parallel_chains(1, num_chains=3, chain_length=3)
+    )
+    for task_graph in graphs:
+        # Ignore the near-zero source/sink placeholder tasks (weight EPS).
+        costs = [task.cost for task in task_graph.tasks if task.cost > EPS]
+        assert len(set(costs)) > 1, "task costs are constant (degenerate instance)"
+
+
+def test_generated_networks_are_not_degenerate():
+    """Random networks have varied node speeds rather than a single value."""
+    random.seed(0)
+    network = gen_random_networks(1, num_nodes=5)[0]
+    speeds = [node.speed for node in network.nodes]
+    assert len(set(speeds)) > 1, "node speeds are constant (degenerate instance)"


### PR DESCRIPTION
## Summary

Fixes #58. The default weight functions in `saga/schedulers/data/random.py` had an inverted `min`/`max` clamp:

```python
return max(min(1e-9, random.gauss(1, 1 / 3)), 2)
```

`min(1e-9, g)` is essentially always `1e-9`, and `max(1e-9, 2)` is always `2`, so both `_default_task_weight` and `_default_dependency_weight` **always returned 2.0**. Every default-generated `in_tree`, `out_tree`, `parallel_chain`, and random network came out fully degenerate (all costs, sizes, and speeds equal to 2.0 — tie-everywhere instances).

The clamp is corrected to:

```python
return min(max(random.gauss(1, 1 / 3), 1e-9), 2)
```

which clamps the Gaussian sample into `[1e-9, 2]` as intended.

## Type of change

- [x] Bug fix

## Tests

Adds `tests/test_data_generators.py` (the generators had no coverage): asserts the default weights stay in `[1e-9, 2]` and vary across draws, and that generated trees/chains/networks have non-degenerate weights. The tests fail on the pre-fix code (constant `2.0`) and pass after.

## Notes for reviewers

A fix for this reportedly already exists on the MILCOM-paper branch (per Mohammadali Khodabandehlou); this is an independent one-line correction with regression coverage.