### PR TITLE
updating throughput experiment to include reschedule counts and makespan

### DIFF
--- a/scripts/experiments/throughput_experiment/analyze.py
+++ b/scripts/experiments/throughput_experiment/analyze.py
@@ -1,8 +1,14 @@
 """Analyze throughput results: per-workflow gradient heatmaps.
 
-Reads results/<branch>_<regime>.csv (from run.py), normalizes throughput per instance
-against the best config on that instance, then writes:
-  - output/<branch>_<regime>/<workflow>.png : median throughput ratio, schedulers x CCR.
+Reads results/<branch>_<regime>.csv (from run.py), normalizes throughput and makespan
+per instance against the best config on that instance, then writes:
+  - output/<branch>_<regime>/<workflow>_throughput.png : median throughput ratio, schedulers x CCR.
+  - output/<branch>_<regime>/<workflow>_makespan.png   : median makespan ratio, schedulers x CCR.
+
+In both cases 1.0 is the best config on that instance, but the direction flips: throughput
+is better when higher, so ThroughputRatio = Throughput / max(Throughput) <= 1 (lower is
+worse); makespan is better when lower, so MakespanRatio = Makespan / min(Makespan) >= 1
+(higher is worse).
 
 Usage:
     python analyze.py riotbench deterministic
@@ -51,8 +57,10 @@ def load(branch: str, regime: str) -> pd.DataFrame:
             f"Usage: python analyze.py <branch> <regime>  (regime = deterministic|stochastic)"
         )
     df = pd.read_csv(path)
-    best = df.groupby(INSTANCE_KEYS)["Throughput"].transform("max")
-    df["Ratio"] = df["Throughput"] / best
+    best_throughput = df.groupby(INSTANCE_KEYS)["Throughput"].transform("max")
+    df["ThroughputRatio"] = df["Throughput"] / best_throughput
+    best_makespan = df.groupby(INSTANCE_KEYS)["Makespan"].transform("min")
+    df["MakespanRatio"] = df["Makespan"] / best_makespan
     return df
 
 
@@ -63,17 +71,21 @@ def heatmaps(df: pd.DataFrame, branch: str, regime: str) -> None:
         # Pass the raw per-instance/seed rows so each cell renders a gradient over its
         # distribution (aggregating to one value per cell would flatten it); the cell
         # label is the mean.
-        cell = group[["Scheduler", "CCR", "Ratio"]]
-        ax = gradient_heatmap(
-            cell, x="CCR", y="Scheduler", color="Ratio",
-            title=f"{branch} / {regime}: {workflow}",
-            x_label="CCR", y_label="scheduler", color_label="throughput ratio (median)",
-            yorder=scheduler_order,
-            cmap="coolwarm_r",  # reverse so high throughput (good) is cool, low is warm/red
-            cell_font_size=14, font_size=14, figsize=(9, 7),
-        )
-        ax.get_figure().savefig(outdir / f"{workflow}.png", bbox_inches="tight", dpi=120)
-        plt.close(ax.get_figure())
+        for metric, ratio_col, cmap in (
+            ("throughput", "ThroughputRatio", "coolwarm_r"),  # high (good) is cool, low is warm/red
+            ("makespan", "MakespanRatio", "coolwarm"),  # low (good) is cool, high is warm/red
+        ):
+            cell = group[["Scheduler", "CCR", ratio_col]]
+            ax = gradient_heatmap(
+                cell, x="CCR", y="Scheduler", color=ratio_col,
+                title=f"{branch} / {regime}: {workflow} ({metric})",
+                x_label="CCR", y_label="scheduler", color_label=f"{metric} ratio (median)",
+                yorder=scheduler_order,
+                cmap=cmap,
+                cell_font_size=14, font_size=14, figsize=(9, 7),
+            )
+            ax.get_figure().savefig(outdir / f"{workflow}_{metric}.png", bbox_inches="tight", dpi=120)
+            plt.close(ax.get_figure())
     print(f"heatmaps -> {outdir}")
 
 

--- a/scripts/experiments/throughput_experiment/run.py
+++ b/scripts/experiments/throughput_experiment/run.py
@@ -99,24 +99,33 @@ def build_config(name: str):
     return BASES[base](), _POLICIES[policy]()
 
 
-def evaluate(regime, scheduler, policy, instance, seed) -> float:
-    """Return the realized throughput of one config on one instance/seed."""
+def evaluate(regime, scheduler, policy, instance, seed) -> dict:
+    """Return the realized throughput, makespan, and reschedule count of one config on one instance/seed."""
     cons = instance.node_constraints
+    reschedule_count = 0
     if regime == "deterministic":
         if policy is None:
             schedule = scheduler.schedule(instance.network, instance.task_graph, node_constraints=cons)
         else:
-            schedule = Environment(
+            env = Environment(
                 instance.network, instance.task_graph,
                 scheduler=scheduler, policy=policy, node_constraints=cons,
-            ).run()
+            )
+            schedule = env.run()
+            reschedule_count = env.reschedule_count
     else:
-        schedule = StochasticEnvironment(
+        env = StochasticEnvironment(
             instance.network, instance.task_graph,
             scheduler=scheduler, estimate=_mean, policy=policy,
             seed=seed, node_constraints=cons,
-        ).run()
-    return schedule.throughput
+        )
+        schedule = env.run()
+        reschedule_count = env.reschedule_count
+    return {
+        "Throughput": schedule.throughput,
+        "Makespan": schedule.makespan,
+        "RescheduleCount": reschedule_count,
+    }
 
 
 def _eval_instance(job):
@@ -128,7 +137,7 @@ def _eval_instance(job):
         for name in config_names(regime):
             scheduler, policy = build_config(name)
             try:
-                throughput = evaluate(regime, scheduler, policy, instance, seed)
+                result = evaluate(regime, scheduler, policy, instance, seed)
             except Exception as e:  # noqa: BLE001
                 logging.warning("failed %s/%s ccr=%s %s seed=%d: %s",
                                 workflow, name, ccr, instance.name, seed, e)
@@ -136,7 +145,8 @@ def _eval_instance(job):
             rows.append({
                 "Branch": None, "Regime": regime, "Workflow": workflow,
                 "CCR": ccr, "Instance": instance.name, "Seed": seed,
-                "Scheduler": name, "Throughput": throughput,
+                "Scheduler": name, "Throughput": result["Throughput"],
+                "Makespan": result["Makespan"], "RescheduleCount": result["RescheduleCount"],
             })
     return rows
 

--- a/src/saga/schedulers/online/environment/__init__.py
+++ b/src/saga/schedulers/online/environment/__init__.py
@@ -190,6 +190,7 @@ class Environment:
         self._step: int = 0
         self.history: List[StepRecord] = []
         self.prev_nready: int = 0
+        self.reschedule_count: int = 0
 
     # ------------------------------------------------------------------
     # Public interface
@@ -208,6 +209,7 @@ class Environment:
         self._step = 0
         self.history = []
         self.prev_nready = 0
+        self.reschedule_count = 0
         if self.policy is not None:
             self.policy.reset()
         if self.scheduler is None:

--- a/src/saga/schedulers/online/environment/frontier.py
+++ b/src/saga/schedulers/online/environment/frontier.py
@@ -68,6 +68,7 @@ class FrontierEnvironment(Environment):
         self.occupied_nodes = set()
         self._step = 0
         self.history = []
+        self.reschedule_count = 0
         if self.policy is not None:
             self.policy.reset()
         self.frontier = []

--- a/src/saga/schedulers/online/policy/reschedule.py
+++ b/src/saga/schedulers/online/policy/reschedule.py
@@ -30,6 +30,7 @@ class ReschedulePolicy(OnlinePolicy):
                 "this may raise at runtime.",
                 type(environment.scheduler).__name__,
             )
+        environment.reschedule_count += 1
         partial = build_partial_schedule(environment)
         if isinstance(environment, StochasticEnvironment):
             new_estimate = environment.stochastic_scheduler.schedule(
@@ -112,6 +113,7 @@ class ConditionalReschedulePolicy(OnlinePolicy):
             scheduled_task=last_finished, environment=environment
         ):
             return environment.schedule
+        environment.reschedule_count += 1
 
         partial = build_partial_schedule(environment)
         if isinstance(environment, StochasticEnvironment):
@@ -157,6 +159,7 @@ class RandomReschedulePolicy10(OnlinePolicy):
             )
         if not self.evaluate_reschedule():
             return environment.schedule
+        environment.reschedule_count += 1
 
         partial = build_partial_schedule(environment)
         if isinstance(environment, StochasticEnvironment):
@@ -202,6 +205,7 @@ class RandomReschedulePolicy25(OnlinePolicy):
             )
         if not self.evaluate_reschedule():
             return environment.schedule
+        environment.reschedule_count += 1
 
         partial = build_partial_schedule(environment)
         if isinstance(environment, StochasticEnvironment):
@@ -247,6 +251,7 @@ class RandomReschedulePolicy50(OnlinePolicy):
             )
         if not self.evaluate_reschedule():
             return environment.schedule
+        environment.reschedule_count += 1
 
         partial = build_partial_schedule(environment)
         if isinstance(environment, StochasticEnvironment):

--- a/src/saga/schedulers/online/policy/reschedule.py
+++ b/src/saga/schedulers/online/policy/reschedule.py
@@ -99,7 +99,7 @@ class ConditionalReschedulePolicy(OnlinePolicy):
                 "ConditionalReschedulePolicy requires a StochasticEnvironment."
             )
         if not environment.finished_tasks:
-            return environment.schedule
+            return None
 
         if not isinstance(environment.scheduler, ParametricScheduler):
             logger.warning(
@@ -112,7 +112,7 @@ class ConditionalReschedulePolicy(OnlinePolicy):
         if not self.evaluate_reschedule(
             scheduled_task=last_finished, environment=environment
         ):
-            return environment.schedule
+            return None
         environment.reschedule_count += 1
 
         partial = build_partial_schedule(environment)
@@ -158,7 +158,7 @@ class RandomReschedulePolicy10(OnlinePolicy):
                 type(environment.scheduler).__name__,
             )
         if not self.evaluate_reschedule():
-            return environment.schedule
+            return None
         environment.reschedule_count += 1
 
         partial = build_partial_schedule(environment)
@@ -204,7 +204,7 @@ class RandomReschedulePolicy25(OnlinePolicy):
                 type(environment.scheduler).__name__,
             )
         if not self.evaluate_reschedule():
-            return environment.schedule
+            return None
         environment.reschedule_count += 1
 
         partial = build_partial_schedule(environment)
@@ -250,7 +250,7 @@ class RandomReschedulePolicy50(OnlinePolicy):
                 type(environment.scheduler).__name__,
             )
         if not self.evaluate_reschedule():
-            return environment.schedule
+            return None
         environment.reschedule_count += 1
 
         partial = build_partial_schedule(environment)

--- a/tests/test_reschedule_count.py
+++ b/tests/test_reschedule_count.py
@@ -1,0 +1,76 @@
+"""Tests for Environment.reschedule_count."""
+
+from typing import Optional
+
+from saga import Schedule
+from saga.schedulers.heft import HeftScheduler
+from saga.schedulers.online.algorithms.fifo import FIFOEnvironment
+from saga.schedulers.online.algorithms.online_heft import OnlineHEFTEnvironment
+from saga.schedulers.online.environment import Environment
+from saga.schedulers.online.policy import OnlinePolicy
+from saga.stochastic import StochasticNetwork, StochasticTaskGraph
+from saga.utils.random_graphs import get_diamond_dag, get_network
+from saga.utils.random_variable import RandomVariable
+
+
+class _NeverReschedule(OnlinePolicy):
+    """A policy that inspects the environment but never revises the schedule."""
+
+    def update(self, environment: Environment) -> Optional[Schedule]:
+        return None
+
+
+def _stochastic_chain():
+    def rv():
+        return RandomVariable(samples=[1.0, 2.0])
+
+    network = StochasticNetwork.create(
+        nodes=[("A", rv()), ("B", rv())], edges=[("A", "B", rv())]
+    )
+    task_graph = StochasticTaskGraph.create(
+        tasks=[("t1", rv()), ("t2", rv()), ("t3", rv())],
+        dependencies=[("t1", "t2", rv()), ("t2", "t3", rv())],
+    )
+    return network, task_graph
+
+
+def test_reschedule_count_starts_at_zero():
+    env = OnlineHEFTEnvironment(*_stochastic_chain())
+    assert env.reschedule_count == 0
+
+
+def test_reschedule_count_resets_each_run():
+    env = OnlineHEFTEnvironment(*_stochastic_chain())
+    env.run()
+    first = env.reschedule_count
+    assert first > 0
+    env.run()
+    assert env.reschedule_count == first  # reset, not accumulated across runs
+
+
+def test_frontier_environment_reset_zeroes_reschedule_count():
+    env = FIFOEnvironment(get_network(num_nodes=4), get_diamond_dag())
+    env.reschedule_count = 7
+    env.reset()
+    assert env.reschedule_count == 0
+
+
+def test_never_rescheduling_policy_leaves_count_zero():
+    # The step loop itself must not touch reschedule_count; only a real reschedule
+    # inside a policy increments it.
+    env = Environment(
+        get_network(num_nodes=4),
+        get_diamond_dag(),
+        scheduler=HeftScheduler(),
+        policy=_NeverReschedule(),
+    )
+    env.run()
+    assert env.history, "the run recorded no steps"
+    assert env.reschedule_count == 0
+
+
+def test_always_rescheduling_policy_counts_every_reschedule():
+    # OnlineHEFT uses ReschedulePolicy, which reschedules on every step.
+    env = OnlineHEFTEnvironment(*_stochastic_chain())
+    env.run()
+    assert env.reschedule_count == len(env.history) > 0


### PR DESCRIPTION
<!--
Thanks for contributing to SAGA. Fill in the sections below and check the boxes
before requesting review. See CONTRIBUTING.md for the full review criteria.
-->

## Summary
Small updates to throughput experiment to include makespan and reschedule count
<!-- What does this change do, and why? Link any related issue with "Closes #123". -->

## Type of change

- [ ] Bug fix
- [ ] New scheduler
- [ ] New feature (other)
- [ ] Refactor / maintenance
- [ ] Docs / CI only

## Checklist

- [ ] Branched off `main` and up to date with it (no conflicts)
- [ ] `uv run pytest tests/ --timeout=120` passes locally
- [ ] `uv run mypy src/saga --ignore-missing-imports` is clean
- [ ] `uv run ruff check src/saga` and `uv run ruff format --check src/saga` are clean
- [ ] New or changed behavior is covered by tests
- [ ] Public functions/classes are typed and documented in the existing docstring style
- [ ] No stray files, debug prints, unintended `pyproject.toml`/`uv.lock` changes, or version bump

## Notes for reviewers

<!-- Anything worth flagging: design tradeoffs, follow-ups, areas you want a close look at. -->
